### PR TITLE
update for latest opensim

### DIFF
--- a/Barasonisx-Dwell-Module/Modules/Barosonix-Dwell-Module/Barosonix-Dwell-Module.cs
+++ b/Barasonisx-Dwell-Module/Modules/Barosonix-Dwell-Module/Barosonix-Dwell-Module.cs
@@ -27,9 +27,6 @@ using GridRegion = OpenSim.Services.Interfaces.GridRegion;
 using Mono.Addins;
 using Nwc.XmlRpc;
 
-[assembly: Addin("BarosonixDwellModule", "0.1")]
-[assembly: AddinDependency("OpenSim", "0.5")]
-
 namespace Barosonix.Dwell.Module
 {
 	[Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "BarosonixDwellModule")]

--- a/Barasonisx-Dwell-Module/Modules/Properties/AssemblyInfo.cs
+++ b/Barasonisx-Dwell-Module/Modules/Properties/AssemblyInfo.cs
@@ -1,0 +1,41 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Mono.Addins;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("BarosonixDwellModule")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("OpenSim.Region.BarosonixDwellModule")]
+[assembly: AssemblyCopyright("Copyright © Barosonix")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4C7A8AFA-7DB4-4F03-A8F7-7DBCB22095E1")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: Addin("BarosonixDwellModule", OpenSim.VersionInfo.VersionNumber + ".2")]
+[assembly: AddinDependency("OpenSim.Region.Framework", OpenSim.VersionInfo.VersionNumber)]
+[assembly: AddinDescription("Region count stats")]
+[assembly: AddinAuthor("Barosonix")]

--- a/WebRoot/databaseinfo.php
+++ b/WebRoot/databaseinfo.php
@@ -1,4 +1,4 @@
-<?
+<?php
 $DB_HOST = "127.0.0.1";
 $DB_USER = "opensim";
 $DB_PASSWORD = "yourpasshere";

--- a/WebRoot/xmlrpc.php
+++ b/WebRoot/xmlrpc.php
@@ -4,6 +4,14 @@ include("databaseinfo.php");
 mysql_connect ($DB_HOST, $DB_USER, $DB_PASSWORD);
 mysql_select_db ($DB_NAME);
 
+/*
+// some config need the reference to xmlrpc if they are not installed already in php
+
+include (__DIR__.'/../xmlrpc/xmlrpc.inc');
+include (__DIR__.'/../xmlrpc/xmlrpcs.inc');
+include (__DIR__.'/../xmlrpc/xmlrpc_extension_api.inc');
+*/
+
 $report ="";
 $xmlrpc_server = xmlrpc_server_create();
 


### PR DESCRIPTION
added AssemblyInfo.cs so that the module is loaded on opensim 0.8.*
The databaseinfo.php had <? , this should be <?php
 Removed the assembly references in the main cs file, since these are
now in the assemblyinfo

added out commented xmlrpc reference to the xmlrpc.php since it not all
php has got xmlrpc installed.